### PR TITLE
Support VERSION constant directly in setup.py

### DIFF
--- a/releaserabbit
+++ b/releaserabbit
@@ -20,36 +20,49 @@ def compile_string_decl_regex(var_name):
     )
 
 
-VERSION_RE = compile_string_decl_regex('__version__')
+class VersionFile(object):
+    def __init__(self, file_name, version_re):
+        self.file_name = file_name
+        self.version_re = version_re
+
+    def get_version(self):
+        return find_string_declaration(self.file_name, self.version_re)
+
+    def replace_version(self, new_version):
+        with io.open(self.file_name, "rt", encoding="utf8") as f:
+            new_content = self.version_re.sub(
+                r'\g<1>\g<2>{}\g<2>'.format(new_version), f.read()
+            )
+
+        with io.open(self.file_name, "wt", encoding="utf8") as f:
+            f.write(new_content)
 
 
 def get_setup_version():
     return get_output('python', 'setup.py', '--version')
 
 
-def get_file_version(version_file):
-    return find_string_declaration(version_file, VERSION_RE)
-
-
-def get_version_filename():
-    return find_string_declaration(
+def get_version_file():
+    # Try __version__ in separate VERSION_FILE
+    file_name = find_string_declaration(
         'setup.py', compile_string_decl_regex('VERSION_FILE')
     )
+    if file_name:
+        return VersionFile(file_name, compile_string_decl_regex('__version__'))
+
+    # Try VERSION directly in setup.py
+    just_version_re = compile_string_decl_regex('VERSION')
+    if find_string_declaration('setup.py', just_version_re):
+        return VersionFile('setup.py', just_version_re)
+
+    raise ValueError('Cannot figure out where your version is set')
 
 
 def find_string_declaration(python_file, string_decl_re):
     with io.open(python_file, "rt", encoding="utf8") as f:
-        return string_decl_re.search(f.read()).group(3)
-
-
-def replace_version(version_file, new_version):
-    with io.open(version_file, "rt", encoding="utf8") as f:
-        new_content = VERSION_RE.sub(
-            r'\g<1>\g<2>{}\g<2>'.format(new_version), f.read()
-        )
-
-    with io.open(version_file, "wt", encoding="utf8") as f:
-        f.write(new_content)
+        match = string_decl_re.search(f.read())
+        if match:
+            return match.group(3)
 
 
 def tag(version, message):
@@ -74,23 +87,23 @@ def main(version):
         == 0
     ), 'Working directory is not clean'
     sh('git', 'pull')
-    ver_file = get_version_filename()
+    ver_file = get_version_file()
     assert ver_file, 'No VERSION_FILE defined in setup.py'
-    old_file_version = get_file_version(ver_file)
+    old_file_version = ver_file.get_version()
     assert get_setup_version() == old_file_version, 'Version does not match'
     assert old_file_version != version, 'Already on {}'.format(version)
 
-    replace_version(ver_file, version)
+    ver_file.replace_version(version)
 
     assert (
-        get_file_version(ver_file) == version
+        ver_file.get_version() == version
     ), 'File version does not match after update'
-    assert get_setup_version() == get_file_version(
-        ver_file
+    assert (
+        get_setup_version() == ver_file.get_version()
     ), 'Setup.py version does not match after update'
     message = 'Version bump to v{}'.format(version)
 
-    sh('git', 'add', ver_file)
+    sh('git', 'add', ver_file.file_name)
     sh('git', 'commit', '-m', message)
 
     tag(version, message)


### PR DESCRIPTION
If you don't want (or cannot easily) to expose `__version__` in a separate file.