### PR TITLE
Bump tested python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/releaserabbit/__init__.py
+++ b/releaserabbit/__init__.py
@@ -19,11 +19,11 @@ def sh(*args):
 
 def compile_string_decl_regex(var_name):
     return re.compile(
-        fr'^({var_name}\s*=\s*)([\'"])(.*?)\2$', re.MULTILINE
+        r'^({}\s*=\s*)([\'"])(.*?)\2$'.format(var_name), re.MULTILINE
     )
 
 
-class VersionFile:
+class VersionFile(object):
     def __init__(self, file_name, version_re):
         self.file_name = file_name
         self.version_re = version_re
@@ -34,7 +34,7 @@ class VersionFile:
     def replace_version(self, new_version):
         with io.open(self.file_name, "rt", encoding="utf8") as f:
             new_content = self.version_re.sub(
-                fr'\g<1>\g<2>{new_version}\g<2>', f.read()
+                r'\g<1>\g<2>{}\g<2>'.format(new_version), f.read()
             )
 
         with io.open(self.file_name, "wt", encoding="utf8") as f:
@@ -69,7 +69,7 @@ def find_string_declaration(python_file, string_decl_re):
 
 
 def tag(version, message):
-    sh('git', 'tag', '-a', f'v{version}', '-m', message)
+    sh('git', 'tag', '-a', 'v{}'.format(version), '-m', message)
 
 
 def build_and_upload():
@@ -137,7 +137,9 @@ def release_with_version(requested_version):
     if requested_version.startswith('v'):
         requested_version = requested_version[1:]
     old_version, ver_file = prepare()
-    assert old_version != requested_version, f'Already on {requested_vesrion}'
+    assert old_version != requested_version, 'Already on {}'.format(
+        requested_version
+    )
 
     version = get_new_version(old_version, requested_version)
 
@@ -149,7 +151,7 @@ def release_with_version(requested_version):
     assert (
         get_setup_version() == ver_file.get_version()
     ), 'Setup.py version does not match after update'
-    message = f'Version bump to v{version}'
+    message = 'Version bump to v{}'.format(version)
 
     sh('git', 'add', ver_file.file_name)
     sh('git', 'commit', '-m', message)
@@ -157,12 +159,12 @@ def release_with_version(requested_version):
     tag(version, message)
     build_and_upload()
 
-    print(f'Updated version to {version}.')
+    print('Updated version to {}.'.format(version))
 
 
 def main():
     if len(sys.argv) != 2:
-        print(f'Usage: {sys.argv[0]} new_version')
+        print('Usage: {} new_version'.format(sys.argv[0]))
         sys.exit(1)
     try:
         release_with_version(sys.argv[1])

--- a/releaserabbit/__init__.py
+++ b/releaserabbit/__init__.py
@@ -23,7 +23,7 @@ def compile_string_decl_regex(var_name):
     )
 
 
-class VersionFile(object):
+class VersionFile:
     def __init__(self, file_name, version_re):
         self.file_name = file_name
         self.version_re = version_re

--- a/releaserabbit/__init__.py
+++ b/releaserabbit/__init__.py
@@ -19,11 +19,11 @@ def sh(*args):
 
 def compile_string_decl_regex(var_name):
     return re.compile(
-        r'^({}\s*=\s*)([\'"])(.*?)\2$'.format(var_name), re.MULTILINE
+        fr'^({var_name}\s*=\s*)([\'"])(.*?)\2$', re.MULTILINE
     )
 
 
-class VersionFile(object):
+class VersionFile:
     def __init__(self, file_name, version_re):
         self.file_name = file_name
         self.version_re = version_re
@@ -34,7 +34,7 @@ class VersionFile(object):
     def replace_version(self, new_version):
         with io.open(self.file_name, "rt", encoding="utf8") as f:
             new_content = self.version_re.sub(
-                r'\g<1>\g<2>{}\g<2>'.format(new_version), f.read()
+                fr'\g<1>\g<2>{new_version}\g<2>', f.read()
             )
 
         with io.open(self.file_name, "wt", encoding="utf8") as f:
@@ -69,7 +69,7 @@ def find_string_declaration(python_file, string_decl_re):
 
 
 def tag(version, message):
-    sh('git', 'tag', '-a', 'v{}'.format(version), '-m', message)
+    sh('git', 'tag', '-a', f'v{version}', '-m', message)
 
 
 def build_and_upload():
@@ -137,9 +137,7 @@ def release_with_version(requested_version):
     if requested_version.startswith('v'):
         requested_version = requested_version[1:]
     old_version, ver_file = prepare()
-    assert old_version != requested_version, 'Already on {}'.format(
-        requested_version
-    )
+    assert old_version != requested_version, f'Already on {requested_vesrion}'
 
     version = get_new_version(old_version, requested_version)
 
@@ -151,7 +149,7 @@ def release_with_version(requested_version):
     assert (
         get_setup_version() == ver_file.get_version()
     ), 'Setup.py version does not match after update'
-    message = 'Version bump to v{}'.format(version)
+    message = f'Version bump to v{version}'
 
     sh('git', 'add', ver_file.file_name)
     sh('git', 'commit', '-m', message)
@@ -159,12 +157,12 @@ def release_with_version(requested_version):
     tag(version, message)
     build_and_upload()
 
-    print('Updated version to {}.'.format(version))
+    print(f'Updated version to {version}.')
 
 
 def main():
     if len(sys.argv) != 2:
-        print('Usage: {} new_version'.format(sys.argv[0]))
+        print(f'Usage: {sys.argv[0]} new_version')
         sys.exit(1)
     try:
         release_with_version(sys.argv[1])

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,1 +1,1 @@
-lintlizard==0.10.0
+lintlizard==0.18.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,1 +1,2 @@
 lintlizard==0.18.0
+click<8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,11 @@ ignore=
     W503,
     W504,
     # This is not PEP8-compliant and conflicts with black
-    E203
+    E203,
+	# "String literal formatting using format method"
+	# This is triggering erroneously on lines that aren't using literal
+	# formatting
+	SFS201
 exclude=venv
 banned-modules=
     typing.Text = use str


### PR DESCRIPTION
3.6 is EOL and now fails building. We should drop it and begin testing newer versions.

This change also:
* bumps `lintlizard` (some newer linter versions are required to run on newer python versions)
* ignores an erroneously altering `SFS201` rule about string literal formatting
* removes `MyClass(object):` object inheritance